### PR TITLE
rename SignedOctets and fix MACedIDForI error

### DIFF
--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -156,8 +156,8 @@ type IKESecurityAssociation struct {
 	LastEAPIdentifier        uint8
 
 	// Authentication data
-	LocalUnsignedAuthentication  []byte
-	RemoteUnsignedAuthentication []byte
+	ResponderSignedOctets []byte
+	InitiatorSignedOctets []byte
 
 	// NAT detection
 	// If UEIsBehindNAT == true, N3IWF should enable NAT traversal and

--- a/pkg/ike/dispatcher.go
+++ b/pkg/ike/dispatcher.go
@@ -49,7 +49,7 @@ func Dispatch(udpConn *net.UDPConn, localAddr, remoteAddr *net.UDPAddr, msg []by
 
 	switch ikeMessage.ExchangeType {
 	case ike_message.IKE_SA_INIT:
-		handler.HandleIKESAINIT(udpConn, localAddr, remoteAddr, ikeMessage)
+		handler.HandleIKESAINIT(udpConn, localAddr, remoteAddr, ikeMessage, msg)
 	case ike_message.IKE_AUTH:
 		handler.HandleIKEAUTH(udpConn, localAddr, remoteAddr, ikeMessage)
 	case ike_message.CREATE_CHILD_SA:

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -31,7 +31,8 @@ func init() {
 	ikeLog = logger.IKELog
 }
 
-func HandleIKESAINIT(udpConn *net.UDPConn, n3iwfAddr, ueAddr *net.UDPAddr, message *ike_message.IKEMessage, realMessage1 []byte) {
+func HandleIKESAINIT(udpConn *net.UDPConn, n3iwfAddr, ueAddr *net.UDPAddr, message *ike_message.IKEMessage,
+	realMessage1 []byte) {
 	ikeLog.Infoln("Handle IKE_SA_INIT")
 
 	// Used to receive value from peer


### PR DESCRIPTION
ref: RFC7296#section-2.15
```
InitiatorSignedOctets = RealMessage1 | NonceRData | MACedIDForI
GenIKEHDR = [ four octets 0 if using port 4500 ] | RealIKEHDR
RealIKEHDR =  SPIi | SPIr |  . . . | Length
RealMessage1 = RealIKEHDR | RestOfMessage1
NonceRPayload = PayloadHeader | NonceRData
InitiatorIDPayload = PayloadHeader | RestOfInitIDPayload
RestOfInitIDPayload = IDType | RESERVED | InitIDData
MACedIDForI = prf(SK_pi, RestOfInitIDPayload)
```