### PR TITLE
modify GetInterfaceName()

### DIFF
--- a/internal/util/initContext.go
+++ b/internal/util/initContext.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"regexp"
 	"io/ioutil"
 	"net"
 	"strings"
@@ -313,14 +312,11 @@ func GetInterfaceName(IPAddress string) (interfaceName string, err error) {
 		return "nil", err
 	}
 
-	re := regexp.MustCompile(`[a-z]`)
-	if (re.MatchString(IPAddress) == true) {
-		res, err := net.ResolveIPAddr("ip4", IPAddress)
-		if err != nil {
-			return "", fmt.Errorf("Error resolving address '%s': %v", IPAddress, err)
-		}
-		IPAddress = res.String()
+	res, err := net.ResolveIPAddr("ip4", IPAddress)
+	if err != nil {
+		return "", fmt.Errorf("Error resolving address '%s': %v", IPAddress, err)
 	}
+	IPAddress = res.String()
 
 	for _, inter := range interfaces {
 		addrs, err := inter.Addrs()

--- a/internal/util/initContext.go
+++ b/internal/util/initContext.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"regexp"
 	"io/ioutil"
 	"net"
 	"strings"
@@ -310,6 +311,15 @@ func GetInterfaceName(IPAddress string) (interfaceName string, err error) {
 	interfaces, err := net.Interfaces()
 	if err != nil {
 		return "nil", err
+	}
+
+	re := regexp.MustCompile(`[a-z]`)
+	if (re.MatchString(IPAddress) == true) {
+		res, err := net.ResolveIPAddr("ip4", IPAddress)
+		if err != nil {
+			return "", fmt.Errorf("Error resolving address '%s': %v", IPAddress, err)
+		}
+		IPAddress = res.String()
 	}
 
 	for _, inter := range interfaces {


### PR DESCRIPTION
In case of IKEBindAddress is domain name, n3iwf can not get the interface name correctly.
This PR is for supporting free5gc v3.2.0 in docker-compose.