### PR TITLE
feat: use max qfi in PDU session as tunnel key

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+sudo ip xfrm policy flush
+sudo ip xfrm state flush
+
+# Remove all GRE interfaces
+GREs=$(ip link show type gre | awk 'NR%2==1 {print $2}' | cut -d @ -f 1)
+for GRE in ${GREs}; do
+    sudo ip link del ${GRE}
+    echo del ${GRE}
+done
+
+# Remove all XFRM interfaces
+XFRMIs=$(ip link show type xfrm | awk 'NR%2==1 {print $2}' | cut -d @ -f 1)
+for XFRMI in ${XFRMIs}; do
+    sudo ip link del ${XFRMI}
+    echo del ${XFRMI}
+done

--- a/pkg/context/ue.go
+++ b/pkg/context/ue.go
@@ -431,3 +431,11 @@ func (ranUe *N3IWFRanUe) DetachAMF() {
 	}
 	delete(ranUe.AMF.N3iwfRanUeList, ranUe.RanUeNgapId)
 }
+
+func (pdusession PDUSession) MaxQFI() uint8 {
+	var maxQfi uint8 = 0
+	for _, qfi := range pdusession.QFIList {
+		maxQfi = max(maxQfi, qfi)
+	}
+	return maxQfi
+}

--- a/pkg/ike/handler/handler.go
+++ b/pkg/ike/handler/handler.go
@@ -1777,6 +1777,7 @@ func CreatePDUSessionChildSA(ikeUe *context.N3IWFIkeUe,
 
 			// Notify-Qos
 			ikePayload.BuildNotify5G_QOS_INFO(uint8(pduSessionID), pduSession.QFIList, true, false, 0)
+			logger.IKELog.Infoln("pduSession", pduSessionID, "QFIList:", pduSession.QFIList)
 
 			// Notify-UP_IP_ADDRESS
 			ikePayload.BuildNotifyUP_IP4_ADDRESS(n3iwfSelf.IPSecGatewayAddress)


### PR DESCRIPTION
## Description 
- Use max QFI value in PDU session as tunnel key

## Test Result
![截圖 2024-06-06 下午12 05 35](https://github.com/free5gc/n3iwf/assets/28786462/3b41e9aa-aac1-4567-aaa2-f49397789cc4)
- `1.1.1.1` has QFI = 3
- `8.8.8.8` has QFI = 1
- In this case, N3IWF would use **QFI = 3** in both GRE packet from `1.1.1.1` and `8.8.8.8` 

## Note
- https://github.com/free5gc/n3iwue/pull/6 