### PR TITLE
fix: remove deprecated cryptographic algorithms

### DIFF
--- a/internal/ike/handler.go
+++ b/internal/ike/handler.go
@@ -1899,8 +1899,6 @@ func isTransformKernelSupported(
 		switch transformID {
 		case ike_message.AUTH_NONE:
 			return false
-		case ike_message.AUTH_HMAC_MD5_96:
-			return true
 		case ike_message.AUTH_HMAC_SHA1_96:
 			return true
 		case ike_message.AUTH_DES_MAC:
@@ -1997,6 +1995,11 @@ func SelectProposal(proposals ike_message.ProposalContainer) ike_message.Proposa
 		var choosePrf prf.PRFType
 
 		for _, transform := range proposal.DiffieHellmanGroup {
+			// block should NOT DH Group 2 in [RFC 8247]
+			if transform.TransformID == ike_message.DH_1024_BIT_MODP {
+				continue
+			}
+
 			dhType := dh.DecodeTransform(transform)
 			if dhType != nil {
 				if diffieHellmanGroupTransform == nil {

--- a/internal/ike/handler.go
+++ b/internal/ike/handler.go
@@ -1986,6 +1986,7 @@ func SelectProposal(proposals ike_message.ProposalContainer) ike_message.Proposa
 
 	for _, proposal := range proposals {
 		// We need ENCR, PRF, INTEG, DH, but not ESN
+		ikeLog := logger.IKELog
 
 		var encryptionAlgorithmTransform, pseudorandomFunctionTransform *ike_message.Transform
 		var integrityAlgorithmTransform, diffieHellmanGroupTransform *ike_message.Transform
@@ -1997,6 +1998,7 @@ func SelectProposal(proposals ike_message.ProposalContainer) ike_message.Proposa
 		for _, transform := range proposal.DiffieHellmanGroup {
 			// block should NOT DH Group 2 in [RFC 8247]
 			if transform.TransformID == ike_message.DH_1024_BIT_MODP {
+				ikeLog.Warn("DH Group 2 is not allowed in Diffie-Hellman Group Transform, skip this transform.")
 				continue
 			}
 


### PR DESCRIPTION
### Description
This PR fixes cryptographic downgrade attacks in IKE_SA_INIT by rejecting weak algorithms (MD5, DH Group 2) during proposal selection and aborting with NO_PROPOSAL_CHOSEN if only insecure options are offered.
This issue is tracked in [issue #974](https://github.com/free5gc/free5gc/issues/974).

### Changes
Added explicit security policy filtering in SelectProposal() to automatically skip DH_1024_BIT_MODP.
Since RFC 8247 uses `should not` rather than `must not`, the DH Group 2 is not deleted but excluded via this filtering.