### PR TITLE
fix(ike/xfrm): enable ESP anti-replay protection by setting ReplayWindow

### DIFF
--- a/internal/ike/xfrm/xfrm.go
+++ b/internal/ike/xfrm/xfrm.go
@@ -97,6 +97,13 @@ func ApplyXFRMRule(n3iwf_is_initiator bool, xfrmiId uint32,
 	xfrmState.Auth = xfrmIntegrityAlgorithm
 	xfrmState.Crypt = xfrmEncryptionAlgorithm
 	xfrmState.ESN = childSecurityAssociation.EsnInfo.GetNeedESN()
+	// A ReplayWindow of 0 tells the Linux kernel to skip ESP sequence
+	// number checking entirely, disabling RFC 4303 anti-replay protection.
+	// Go zero-initializes the field, so every N3IWF Child SA (control-plane
+	// and user-plane) shipped with replay protection off. Use the common
+	// default window size of 32 packets; ESN-enabled SAs still honour the
+	// same field (kernel treats it as the sliding window size).
+	xfrmState.ReplayWindow = 32
 
 	// Commit xfrm state to netlink
 	var err error

--- a/internal/ike/xfrm/xfrm.go
+++ b/internal/ike/xfrm/xfrm.go
@@ -97,12 +97,7 @@ func ApplyXFRMRule(n3iwf_is_initiator bool, xfrmiId uint32,
 	xfrmState.Auth = xfrmIntegrityAlgorithm
 	xfrmState.Crypt = xfrmEncryptionAlgorithm
 	xfrmState.ESN = childSecurityAssociation.EsnInfo.GetNeedESN()
-	// A ReplayWindow of 0 tells the Linux kernel to skip ESP sequence
-	// number checking entirely, disabling RFC 4303 anti-replay protection.
-	// Go zero-initializes the field, so every N3IWF Child SA (control-plane
-	// and user-plane) shipped with replay protection off. Use the common
-	// default window size of 32 packets; ESN-enabled SAs still honour the
-	// same field (kernel treats it as the sliding window size).
+	// Enable RFC 4303 anti-replay protection (zero disables it).
 	xfrmState.ReplayWindow = 32
 
 	// Commit xfrm state to netlink


### PR DESCRIPTION
## Summary

`ApplyXFRMRule` allocates both the inbound and outbound `netlink.XfrmState` via `new(netlink.XfrmState)` and never sets `ReplayWindow`. Go zero-initializes the field, so the netlink message to the kernel carries `ReplayWindow = 0`, which tells Linux to skip ESP sequence-number checking entirely — disabling RFC 4303 §3.4.3 anti-replay protection on every Child SA N3IWF creates, including the 3GPP control-plane SA and user-plane SAs.

## Fix

Set `xfrmState.ReplayWindow = 32` before the first `XfrmStateAdd`. The second `XfrmStateAdd` mutates and reuses the same pointer, so the single assignment covers both inbound and outbound commits. 32 matches the default window size used by mainline IPsec userspace stacks and is a conservative choice for ESN-enabled SAs (kernel treats it as the sliding window size).

Fixes free5gc/free5gc#992.

## Test

- `GOOS=linux go build ./...` green (xfrm package is Linux-only).
- `GOOS=linux go vet ./internal/ike/xfrm/...` clean.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
