### PR TITLE
ike/handler: reject CREATE_CHILD_SA response with empty Proposals

### DIFF
--- a/internal/ike/handler.go
+++ b/internal/ike/handler.go
@@ -1017,6 +1017,11 @@ func (s *Server) continueCreateChildSA(
 	// Get xfrm needed data
 	// As specified in RFC 7296, ESP negotiate two child security association (pair) in one exchange
 	// Message ID is used to be a index to pair two SPI in serveral IKE messages.
+	if temporaryIkeMsg.SecurityAssociation == nil ||
+		len(temporaryIkeMsg.SecurityAssociation.Proposals) == 0 {
+		ikeLog.Errorln("CREATE_CHILD_SA response carried no Proposals; aborting child SA setup")
+		return
+	}
 	outboundSPI := binary.BigEndian.Uint32(temporaryIkeMsg.SecurityAssociation.Proposals[0].SPI)
 	childSecurityAssociationContext, err := ikeUe.CompleteChildSA(
 		ikeSecurityAssociation.ResponderMessageID, outboundSPI, temporaryIkeMsg.SecurityAssociation)

--- a/internal/ike/handler.go
+++ b/internal/ike/handler.go
@@ -1022,7 +1022,12 @@ func (s *Server) continueCreateChildSA(
 		ikeLog.Errorln("CREATE_CHILD_SA response carried no Proposals; aborting child SA setup")
 		return
 	}
-	outboundSPI := binary.BigEndian.Uint32(temporaryIkeMsg.SecurityAssociation.Proposals[0].SPI)
+	proposal := temporaryIkeMsg.SecurityAssociation.Proposals[0]
+	if len(proposal.SPI) != 4 {
+		ikeLog.Errorf("CREATE_CHILD_SA response carried invalid ESP SPI length: %d", len(proposal.SPI))
+		return
+	}
+	outboundSPI := binary.BigEndian.Uint32(proposal.SPI)
 	childSecurityAssociationContext, err := ikeUe.CompleteChildSA(
 		ikeSecurityAssociation.ResponderMessageID, outboundSPI, temporaryIkeMsg.SecurityAssociation)
 	if err != nil {


### PR DESCRIPTION
## Summary

`continueCreateChildSA` indexes `temporaryIkeMsg.SecurityAssociation.Proposals[0].SPI` without checking the slice length. The upstream IKE SA payload parser accepts an empty `Proposals` list, so a single crafted `CREATE_CHILD_SA` response with an empty proposal set triggers a runtime out-of-range panic in the live IKE handler goroutine and tears the whole `n3iwf` process down. An authenticated peer can trivially DoS every UE attached to the N3IWF.

## Fix

Guard against both a nil `SecurityAssociation` pointer and an empty `Proposals` slice. Log and abort the child-SA setup path cleanly instead of panicking.

Fixes free5gc/free5gc#989.

## Test

- `GOOS=linux go build ./...` green.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
