### PR TITLE
gre: bounds-check GRE header fields during Unmarshal

### DIFF
--- a/internal/gre/message.go
+++ b/internal/gre/message.go
@@ -39,6 +39,9 @@ func (p *GREPacket) Marshal() []byte {
 }
 
 func (p *GREPacket) Unmarshal(b []byte) error {
+	if len(b) < 4 {
+		return errors.Errorf("GRE packet too short: got %d bytes, need at least 4", len(b))
+	}
 	p.flags = b[0]
 	p.version = b[1]
 
@@ -47,6 +50,10 @@ func (p *GREPacket) Unmarshal(b []byte) error {
 	offset := 4
 
 	if p.GetKeyFlag() {
+		if len(b) < offset+GREHeaderKeyFieldLength {
+			return errors.Errorf("GRE packet too short for Key field: got %d bytes, need %d",
+				len(b), offset+GREHeaderKeyFieldLength)
+		}
 		p.key = binary.BigEndian.Uint32(b[offset : offset+GREHeaderKeyFieldLength])
 		offset += GREHeaderKeyFieldLength
 	}

--- a/internal/gre/message_test.go
+++ b/internal/gre/message_test.go
@@ -1,0 +1,58 @@
+package gre
+
+import (
+	"testing"
+)
+
+func TestGREPacketUnmarshalShortBuffer(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{name: "empty", buf: []byte{}},
+		{name: "one byte", buf: []byte{0x00}},
+		{name: "two bytes", buf: []byte{0x20, 0x00}},
+		{name: "three bytes", buf: []byte{0x20, 0x00, 0x08}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Unmarshal panicked on short buffer: %v", r)
+				}
+			}()
+			var p GREPacket
+			if err := p.Unmarshal(tc.buf); err == nil {
+				t.Fatalf("expected error for %d-byte buffer, got nil", len(tc.buf))
+			}
+		})
+	}
+}
+
+func TestGREPacketUnmarshalKeyFlagTruncated(t *testing.T) {
+	// flags byte 0x20 sets the Key flag.
+	buf := []byte{0x20, 0x00, 0x08, 0x00}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Unmarshal panicked with Key flag + no Key field: %v", r)
+		}
+	}()
+	var p GREPacket
+	if err := p.Unmarshal(buf); err == nil {
+		t.Fatal("expected error for Key-flag buffer with no Key field, got nil")
+	}
+}
+
+func TestGREPacketUnmarshalValid(t *testing.T) {
+	buf := []byte{0x00, 0x00, 0x08, 0x00, 0x01, 0x02, 0x03}
+	var p GREPacket
+	if err := p.Unmarshal(buf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.protocolType != IPv4 {
+		t.Fatalf("protocolType = %d, want %d", p.protocolType, IPv4)
+	}
+	if string(p.payload) != string([]byte{0x01, 0x02, 0x03}) {
+		t.Fatalf("payload mismatch: got %v", p.payload)
+	}
+}


### PR DESCRIPTION
## Summary

`GREPacket.Unmarshal` reads `b[0]`, `b[1]`, `b[2:4]`, and the optional Key field without any length check. A GRE frame smaller than 4 bytes injected through the NWu IPsec tunnel triggers a runtime out-of-range panic in `binary.BigEndian.Uint16(b[2:4])`. The `nwuup` `forwardUL` recover block then calls `Fatalf`, which `os.Exit(1)`s, tearing down the whole N3IWF process.

Any peer that can put bytes into the IPsec tunnel (so any attached UE) can DoS every other UE attached to the same N3IWF with a single 2-byte packet.

## Fix

Add explicit length checks before each indexed read and return a descriptive error instead of panicking. Applied at both the 4-byte base header and the Key-field extension point.

Add `internal/gre/message_test.go` covering empty / 1-byte / 2-byte / 3-byte buffers, the "Key flag set but no Key field" case, and a happy-path round-trip.

Fixes free5gc/free5gc#987.

## Test

- `go test ./internal/gre/... -count=1`, all three new cases + happy path pass.
- `gofmt` clean.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>